### PR TITLE
release/v1.0.3a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.3a] - 2024/06/21
+
+### Updated
+- The CLI parameters `-la/-lo` are no more mandatory for `findings` queries.
+- The queries that list external access findings and rely on `list_regions` to discover available regions and analyzers can now be performed from the management account. However, the recommendation is to [use the management account only for tasks that require the management account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_best-practices_mgmt-acct.html#bp_mgmt-acct_use-mgmt). Data perimeter helper shall be used from a [`security tooling` account](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/architecture.html).
+- Upgrade of requirements' versions.
+- Minor code lint.
+
 ## [1.0.3] - 2024/05/06
 
 ### Added

--- a/data_perimeter_helper/__init__.py
+++ b/data_perimeter_helper/__init__.py
@@ -3,4 +3,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-__version__ = "1.0.3"
+__version__ = "1.0.3a"

--- a/data_perimeter_helper/findings/ExternalAccessAnalyzer.py
+++ b/data_perimeter_helper/findings/ExternalAccessAnalyzer.py
@@ -92,25 +92,14 @@ class ExternalAccessAnalyzer():
         return client
 
     @classmethod
-    def get_account_id(cls) -> str:
-        """Get the AWS account ID of the in-use boto3 session"""
-        if cls.account_id is not None:
-            return cls.account_id
-        cls.account_id = cls.get_boto3_client('sts').get_caller_identity(
-        )['Account']
-        return cls.account_id
-
-    @classmethod
     def get_enabled_regions(cls):
         """Get enabled AWS regions"""
         if len(cls.list_enabled_region) > 0:
             return cls.list_enabled_region
         list_region_code = []
-        account_id = cls.get_account_id()
         account_client = cls.get_boto3_client('account')
         try:
             list_region = account_client.list_regions(
-                AccountId=account_id,
                 RegionOptStatusContains=[
                     'ENABLED', 'ENABLED_BY_DEFAULT'
                 ]

--- a/data_perimeter_helper/main.py
+++ b/data_perimeter_helper/main.py
@@ -332,7 +332,10 @@ def main(args=None) -> int:
     """Main function
     :return: 0 if succeeds
     """
-    arguments = cli.setup_dph_args_parser(args)
+    arguments = cli.setup_dph_args_parser(
+        args,
+        tuple(Var.standalone_query_types)
+    )
     # Retrieve arguments that result in an exit
     if arguments.version:
         return utils.print_dph_version()

--- a/data_perimeter_helper/toolbox/cli.py
+++ b/data_perimeter_helper/toolbox/cli.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 regex_is_accountid = re.compile(r"^\d{12}$")
 
 
-def validate_args(arguments: argparse.Namespace) -> None:
+def validate_args(
+    arguments: argparse.Namespace,
+    tuple_standalone_query_type: tuple
+) -> None:
     """ Validates format of CLI arguments
 
     :param arguments: arguments provided in the CLI
@@ -35,19 +38,18 @@ def validate_args(arguments: argparse.Namespace) -> None:
     if len(list_query) == 0:
         raise ValueError("--list-query/-lq must be defined")
     if len(list_account) == 0 and len(list_ou) == 0:
-        referential_query_present = False
-        standard_query_present = False
         for query in list_query:
-            if query.startswith("referential"):
-                referential_query_present = True
-            else:
-                standard_query_present = True
-                break
-        if (referential_query_present is False) or (standard_query_present is True):
-            raise ValueError("--list-account/-la or --list-ou/-lo must be defined")
+            if not query.startswith(tuple_standalone_query_type):
+                raise ValueError(
+                    "--list-account/-la or --list-ou/-lo must be defined "
+                    f"for provided query `{query}`"
+                )
 
 
-def setup_dph_args_parser(args) -> argparse.Namespace:
+def setup_dph_args_parser(
+    args,
+    tuple_standalone_query_type: tuple
+) -> argparse.Namespace:
     """ Parser for arguments passed to command line (CLI) for dph
 
     :return: List of arguments passed to command line
@@ -172,7 +174,10 @@ def setup_dph_args_parser(args) -> argparse.Namespace:
         help='Display data perimeter helper version'
     )
     arguments = parser.parse_args(args)
-    validate_args(arguments)
+    validate_args(
+        arguments,
+        tuple_standalone_query_type
+    )
     return arguments
 
 

--- a/data_perimeter_helper/toolbox/exporter.py
+++ b/data_perimeter_helper/toolbox/exporter.py
@@ -149,7 +149,9 @@ def export_list_dataframe_to_html(
 
 def excel_convert_date_type(df: pandas.DataFrame) -> None:
     """Convert date types for Excel exports"""
-    date_columns = df.select_dtypes(include=['datetime64[ns, UTC]']).columns
+    date_columns = df.select_dtypes(
+        include=['datetime64[ns, UTC]']  # type: ignore
+    ).columns
     for date_column in date_columns:
         df[date_column] = df[date_column].dt.date
 

--- a/lint/safety.yaml
+++ b/lint/safety.yaml
@@ -1,0 +1,7 @@
+security:
+  ignore-cvss-severity-below: 0
+  ignore-cvss-unknown-severity: False
+  ignore-vulnerabilities:
+    70612:
+      reason: The `from_string` function is not used and trusted Jinja2 templates are used. See https://data.safetycli.com/v/70612/97c/.
+      expires: '2024-10-01'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-boto3==1.34.93
-awswrangler==3.7.3
-pandas==2.2.0
+boto3==1.34.131
+awswrangler==3.8.0
+pandas==2.2.2
 numpy==1.26.4
 tqdm==4.66.4
-openpyxl==3.1.2
+openpyxl==3.1.4
 jinja2==3.1.4
 PyYAML==6.0.1
-pyarrow==16.0.0
+pyarrow==16.1.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     version=__version__,
     description='Helper tool to build data perimeter controls',
     author='Achraf MOUSSADEK-KABDANI',
-    author_email='akabdani@amazon.com',
     license="MIT",
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
- The CLI parameters `-la/-lo` are no more mandatory for `findings` queries.
- The queries that list external access findings and rely on `list_regions` to discover available regions and analyzers can now be performed from the management account. However, the recommendation is to [use the management account only for tasks that require the management account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_best-practices_mgmt-acct.html#bp_mgmt-acct_use-mgmt). Data perimeter helper shall be used from a [`security tooling` account](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/architecture.html).
- Upgrade of requirements' versions.
- Minor code lint.