### PR TITLE
add: merged results, add: common_identity_perimeter_org, update: time…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+
+## [1.0.4] - 2024/07/02
+
+### Added
+- You can now use the query `common_identity_perimeter_org_boundary` to list AWS API calls made on the resources in the selected account by principals that do **NOT** belong to the same AWS organization, filtering out calls that align with your definition of trusted identities. Use this query to accelerate implementation of the [**identity perimeter**](https://aws.amazon.com/blogs/security/establishing-a-data-perimeter-on-aws-allow-only-trusted-identities-to-access-company-data/) controls on your resources at the organization level.
+- When you apply queries against more than two accounts, queries' results are exported to one file per account - each file names prefixed with the targeted account ID. Now, to ease results review across multiple accounts, results are merged to a single file prefixed with `all`.
+
+### Updated
+- Timestamps are now used to manage cache expiration. When the tools import from cache it now displays the date on which it was cached.
+- The function `perf_counter` is now only used to measure execution time.
+
+
 ## [1.0.3a] - 2024/06/21
 
 ### Updated

--- a/data_perimeter_helper/queries/common/common_identity_perimeter_org_boundary.py
+++ b/data_perimeter_helper/queries/common/common_identity_perimeter_org_boundary.py
@@ -3,7 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 '''
-This module implements the query: s3_bucket_policy_identity_perimeter_org_boundary
+This module implements the query: common_identity_perimeter_org_boundary
 '''
 import logging
 from typing import (
@@ -17,9 +17,6 @@ import pandas
 
 from data_perimeter_helper.queries import (
     helper
-)
-from data_perimeter_helper.queries.s3 import (
-    helper_s3
 )
 from data_perimeter_helper.variables import (
     Variables as Var
@@ -41,17 +38,15 @@ def explain_results(
     return "Principal is not part of the current organization"
 
 
-class s3_bucket_policy_identity_perimeter_org_boundary(Query):
-    """List AWS API calls made on S3 buckets in the selected account by principals that do **NOT** belong to the same AWS organization, filtering out calls that align with your definition of trusted identities.
+class common_identity_perimeter_org_boundary(Query):
+    """List AWS API calls made on resources in the selected account by principals that do **NOT** belong to the same AWS organization, filtering out calls that align with your definition of trusted identities.
 
-You can use this query to accelerate implementation of the [**identity perimeter**](https://aws.amazon.com/blogs/security/establishing-a-data-perimeter-on-aws-allow-only-trusted-identities-to-access-company-data/) controls on your S3 buckets at the organization level. You can use the global condition key [aws:PrincipalOrgId](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid) to limit access to your resources to principals belonging to your AWS organization.
+You can use this query to accelerate implementation of the [**identity perimeter**](https://aws.amazon.com/blogs/security/establishing-a-data-perimeter-on-aws-allow-only-trusted-identities-to-access-company-data/) controls on your resources at the organization level. You can use the global condition key [aws:PrincipalOrgId](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid) to limit access to your resources to principals belonging to your AWS organization.
     """  # noqa: W291
     def __init__(self, name):
         self.name = name
         depends_on_resource_type = [
-            'AWS::IAM::Role',
             'AWS::Organizations::Account',
-            'AWS::S3::Bucket'
         ]
         super().__init__(
             name,
@@ -65,10 +60,6 @@ You can use this query to accelerate implementation of the [**identity perimeter
     ) -> Union[None, Tuple[str, List[str]]]:
         """Generate the Athena SQL query"""
         params: List[str] = []
-        keep_selected_account_s3_bucket = helper_s3.get_athena_selected_account_s3_bucket(
-            account_id=account_id,
-            with_negation=False
-        )
         remove_org_account_principals = helper.get_athena_selected_org_account_principals(
             with_negation=True
         )
@@ -95,21 +86,18 @@ You can use this query to accelerate implementation of the [**identity perimeter
         )
         statement = f"""-- Query: {self.name} | {account_id}
 SELECT
-    useridentity.sessioncontext.sessionissuer.arn as principal_arn,
     useridentity.type as principal_type,
     useridentity.accountid as principal_accountid,
     useridentity.principalid,
-    JSON_EXTRACT_SCALAR(requestparameters, '$.bucketName') AS bucketname,
-    sourceipaddress,
-    vpcendpointid,
+    eventsource,
+    eventname,
+    requestparameters,
+    resources,
     count(*) as nb_reqs
 FROM "__ATHENA_TABLE_NAME_PLACEHOLDER__"
 WHERE
     p_account = '{account_id}'
     AND p_date {helper.get_athena_date_partition()}
-    AND eventsource = 's3.amazonaws.com'
-    -- Keep only API calls on S3 buckets in the selected account - list of S3 buckets retrieved from AWS Config aggregator
-    {keep_selected_account_s3_bucket}
     -- Remove API calls made by principals belonging to the same AWS organization as the selected account - list of account ID retrieved from AWS Organizations
     {remove_org_account_principals}
     -- Remove API calls made by principals belonging to identity perimeter trusted accounts - retrieved from the `data perimeter helper` configuration file (`identity_perimeter_trusted_account` parameter).
@@ -119,18 +107,18 @@ WHERE
     {identity_perimeter_trusted_principal_id}
     -- Remove API calls made by AWS service principals - `useridentity.principalid` field in CloudTrail log equals `AWSService`.
     AND useridentity.principalid != 'AWSService'
-    -- Remove S3 preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration
+    -- Remove preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration
     AND eventname != 'PreflightRequest'
     -- Remove API calls with errors
     AND errorcode IS NULL
 GROUP BY
-    useridentity.sessioncontext.sessionissuer.arn,
     useridentity.type,
     useridentity.accountid,
     useridentity.principalid,
-    JSON_EXTRACT_SCALAR(requestparameters, '$.bucketName'),
-    vpcendpointid,
-    sourceipaddress
+    eventsource,
+    eventname,
+    requestparameters,
+    resources
 """  # nosec B608
         return statement, params
 
@@ -148,16 +136,6 @@ GROUP BY
                 "query": athena_query,
                 "dataframe": result
             }
-        logger.debug("[~] Removing bucket specific exceptions")
-        result = self.remove_all_resource_exception(
-            account_id=account_id,
-            dataframe=result,
-            resource_type="AWS::S3::Bucket",
-            resource_id_column_name="bucketname",
-            list_exception_type_to_consider=[
-                "identity_perimeter_trusted_principal"
-            ]
-        )
         if len(result.index):
             logger.debug("[~] Writing parameters [controlType && findings]")
             result['controlType'] = "identity_perimeter"

--- a/data_perimeter_helper/queries/referential/referential_scp.py
+++ b/data_perimeter_helper/queries/referential/referential_scp.py
@@ -75,7 +75,7 @@ You can use this query to assess and accelerate the implemention of your [**reso
 
     def export_scp_readable_format(self, df: pandas.DataFrame) -> None:
         """Export SCPs to files in a readable format"""
-        baseline_export_folder = f"{Var.result_export_folder}/scp/"
+        baseline_export_folder = f"{Var.result_export_folder}/scp"
         for policy_id, policy_name, policy_document, targets in zip(
             df['Id'],
             df['Name'],

--- a/data_perimeter_helper/queries/s3/s3_bucket_policy_identity_perimeter_ou_boundary.py
+++ b/data_perimeter_helper/queries/s3/s3_bucket_policy_identity_perimeter_ou_boundary.py
@@ -129,7 +129,7 @@ WHERE
     {identity_perimeter_trusted_principal_id}
     -- Remove API calls made by AWS service principals - `useridentity.principalid` field in CloudTrail log equals `AWSService`.
     AND useridentity.principalid != 'AWSService'
-    -- Remove preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration
+    -- Remove S3 preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration
     AND eventname != 'PreflightRequest'
     -- Remove API calls with errors
     AND errorcode IS NULL

--- a/data_perimeter_helper/referential/Referential.py
+++ b/data_perimeter_helper/referential/Referential.py
@@ -86,7 +86,7 @@ class Referential:
                     if exception:
                         raise exception
                     resource_type = pool[request_in_pool]['resource_type']
-                    exec_time = utils.get_elapsed_time(
+                    exec_time = utils.get_readable_elapsed_perf_time(
                         pool[request_in_pool]['start_time']  # type: ignore
                     )
                     result = request_in_pool.result()
@@ -153,7 +153,7 @@ class Referential:
             return
         registry = cls.get_resource_type_registry_items()
         metadata = {}
-        timestamp = utils.current_time()
+        timestamp = utils.current_timestamp()
         try:
             metadata = utils.read_json_file(
                 f"{Var.cache_folder_path}/metadata.json"

--- a/data_perimeter_helper/referential/ResourceType.py
+++ b/data_perimeter_helper/referential/ResourceType.py
@@ -193,12 +193,12 @@ class ResourceType:
             logger.debug(log_msg)
             return False
         # Check if the cache for this resource type has expired
-        if isinstance(Var.cache_expire_after_in_second, int) and utils.has_expired(
+        if isinstance(Var.cache_expire_after_in_second, int) and utils.has_expired_timestamp(
             timestamp, expire_second=Var.cache_expire_after_in_second
         ):
             log_msg = f"The cache for resource type `{self.type_name}` "\
-                f"generated {utils.get_elapsed_time(timestamp)} ago has "\
-                "expired. The import of this resource type is skipped."
+                f"generated the {utils.get_readable_timestamp(timestamp)} "\
+                "has expired. The import of this resource type is skipped."
             tqdm.write(
                 utils.color_string(
                     utils.Icons.INFO + log_msg,
@@ -207,14 +207,15 @@ class ResourceType:
             )
             logger.debug(log_msg)
             return False
-        start_time = utils.current_time()
+        start_time = utils.current_perf_time()
         self.dataframe = pandas.read_parquet(
             str(resource_type_metadata['path'])
         )
         self.dataframe_from_cache = True
         log_msg = f"Successfully imported resource type `{self.type_name}` "\
-            f"(generated {utils.get_elapsed_time(timestamp)} ago) from cache "\
-            f"in {utils.get_elapsed_time(start_time)}!"
+            f"generated the {utils.get_readable_timestamp(timestamp)} "\
+            "from cache "\
+            f"in {utils.get_readable_elapsed_perf_time(start_time)}!"
         tqdm.write(
             utils.color_string(
                 utils.Icons.FULL_CHECK_GREEN + log_msg,

--- a/data_perimeter_helper/toolbox/dph_doc.py
+++ b/data_perimeter_helper/toolbox/dph_doc.py
@@ -77,7 +77,7 @@ WHERE_DOCUMENTATION = {
     "AND COALESCE(NOT regexp_like(requestparameters, ':{account_id}:storage-lens|{account_id}.s3-control'), True)": "Remove API calls with the selected account ID in the request parameters (example: GetStorageLensConfiguration).",
     "AND unnested_resources.type IS DISTINCT FROM 'AWS::S3::Object'": "Remove the unnested values of the `resources` field in CloudTrail with `resource.type`=`AWS::S3::Object`. Another unnested row exists with `resources.type`=`AWS::S3::Bucket` and `resources.accountid` distinct from NULL.",
     "AND COALESCE(unnested_resources.accountid NOT IN ({list_all_account_id}), True)": "Remove API calls on S3 buckets owned by accounts belonging to the same AWS organization as the selected account.",
-    "AND eventname != 'PreflightRequest'": "Remove preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration."
+    "AND eventname != 'PreflightRequest'": "Remove S3 preflight requests which are unauthenticated and used to determine the cross-origin resource sharing (CORS) configuration."
 }
 
 WHERE_SKIP_DOCUMENTATION = [

--- a/data_perimeter_helper/toolbox/exporter.py
+++ b/data_perimeter_helper/toolbox/exporter.py
@@ -219,7 +219,7 @@ def export_list_dataframe_to_excel(
     except PermissionError:
         logger.error(
             "[!] Permission error while exporting file [%s]. "
-            "Close the file to allow export.",
+            "If you have opened the file, close it to allow the export.",
             full_path
         )
         logger.info("[!] Skipping export for [%s]", full_path)

--- a/data_perimeter_helper/toolbox/utils.py
+++ b/data_perimeter_helper/toolbox/utils.py
@@ -16,7 +16,8 @@ from os import (
 from time import (
     perf_counter,
     gmtime,
-    strftime
+    strftime,
+    time
 )
 from functools import (
     wraps
@@ -194,12 +195,12 @@ def decorator_elapsed_time(
     def _decorator(_fct):
         @wraps(_fct)
         def wrapper(*args, **kwargs):
-            start_time = current_time()
+            start_time = current_perf_time()
             result = _fct(*args, **kwargs)
             if (result is None) or (result is False):
                 return result
             log = color_string(
-                f"{message}{get_elapsed_time(start_time)}!",
+                f"{message}{get_readable_elapsed_perf_time(start_time)}!",
                 color
             )
             logger.debug(log)
@@ -209,29 +210,43 @@ def decorator_elapsed_time(
     return _decorator if callable(decorated_fct) else _decorator
 
 
-def current_time() -> float:
-    """Return current timestamp"""
+def current_perf_time() -> float:
+    """Returns the float value of time in seconds.
+    The reference point of the returned value is undefined, so that only the
+    difference between the results of consecutive calls is valid."""
     return perf_counter()
 
 
-def get_elasped_timestamp(start_time: float) -> float:
-    return current_time() - start_time
+def get_readable_elapsed_perf_time(start_perf_time: float) -> str:
+    """Returns a readable elapsed time using perf_counter."""
+    return strftime(
+        "%Hh:%Mm:%Ss",
+        gmtime(current_perf_time() - start_perf_time)
+    )
 
 
-def get_elapsed_time(start_time: float) -> str:
-    """Return elapsed"""
-    return strftime("%Hh:%Mm:%Ss", gmtime(get_elasped_timestamp(start_time)))
+def current_timestamp() -> float:
+    """Returns current timestamp."""
+    return time()
 
 
-def has_expired(
-    start_time: float,
+def get_readable_timestamp(timestamp: float):
+    """Returns readable date using as input a timestamp."""
+    return strftime(
+        "%d %B %Y at %Hh:%Mm:%Ss (UTC)",
+        gmtime(timestamp)
+    )
+
+
+def has_expired_timestamp(
+    start_timestamp: float,
     expire_day: int = 0,
     expire_hour: int = 0,
     expire_minute: int = 0,
     expire_second: int = 0
 ) -> bool:
     """Return True if the elapsed timestamp has expired"""
-    return get_elasped_timestamp(start_time) >\
+    return current_timestamp() - start_timestamp >\
         (expire_day * 1440 + expire_hour * 60 + expire_minute) * 60 + expire_second
 
 


### PR DESCRIPTION
### Added
- You can now use the query `common_identity_perimeter_org_boundary` to list AWS API calls made on the resources in the selected account by principals that do **NOT** belong to the same AWS organization, filtering out calls that align with your definition of trusted identities. Use this query to accelerate implementation of the [**identity perimeter**](https://aws.amazon.com/blogs/security/establishing-a-data-perimeter-on-aws-allow-only-trusted-identities-to-access-company-data/) controls on your resources at the organization level.
- When you apply queries against more than two accounts, queries' results are exported to one file per account - each file names prefixed with the targeted account ID. Now, to ease results review across multiple accounts, results are merged to a single file prefixed with `all`.

### Updated
- Timestamps are now used to manage cache expiration. When the tools import from cache it now displays the date on which it was cached.
- The function `perf_counter` is now only used to measure execution time.